### PR TITLE
build(changelog): release v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-pendo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "An ember-metrics integration for Pendo.",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
## Chore

### Create `@dependabot` config file (#18)

## Features

### Upgrade to ember 3.20 (#31)

- Update dependencies and code to fit Ember 3.20
- Update CircleCI config

## Build

### Update `ember-metrics` to latest (#72)

Refactor `pendo` `metrics-adapter` to match changes in `ember-metrics` (see [changelog#1.15.0](https://github.com/adopted-ember-addons/ember-metrics/blob/a8365875d2dd49aaac291cea34b35f32dcfa4f68/CHANGELOG.md#v0150) ; replace use of `canUseDOM` to a check on `supportsFastBoot`)

### Add `ember-classic-decorator` to dependencies (#72)

[ember-metrics](https://github.com/adopted-ember-addons/ember-metrics) use native class but still use `init` methods on their adapters, without using `@classic` decorator

As we use a recent version of `eslint-plugin-ember` (10.0.2) which throw lint errors when using native class and `init` method, we have to add `ember-classic-decorator` here so that we ensure we don't have bad behaviors, ideally `init` code inside `ember-metrics` `BaseAdapter` should be, i guess, moved to `constructor`

When they will refactor on their side (like when they will update `eslint-plugin-ember` and have warning) we should be able to remove this dependencies

### Upgrade dependencies

- build(deps): bump lodash from 4.17.15 to 4.17.19 #19
- build(deps): bump elliptic from 6.5.2 to 6.5.3 #22
- build(deps-dev): bump @ember/optional-features from 1.3.0 to 2.0.0 #34
- build(deps-dev): bump sinon from 7.5.0 to 9.2.0 #33
- build(deps-dev): bump ember-resolver from 8.0.0 to 8.0.2 #38
- build(deps-dev): bump sinon from 9.2.0 to 9.2.1 #37
- build(deps-dev): bump qunit-dom from 1.2.0 to 1.5.0 #40
- build(deps-dev): bump ember-load-initializers from 2.1.1 to 2.1.2 #41
- build(deps-dev): bump eslint from 7.11.0 to 7.14.0 #44
- build(deps-dev): bump qunit-dom from 1.5.0 to 1.6.0 #46
- build(deps-dev): bump ember-source from 3.20.5 to 3.23.1 #45
- build(deps-dev): bump eslint-plugin-ember from 9.6.0 to 10.0.2 #48
- build(deps-dev): bump ember-template-lint from 2.14.0 to 2.15.0 #49
- build(deps-dev): bump ember-source-channel-url from 2.0.1 to 3.0.0 #50
- build(deps): bump ini from 1.3.5 to 1.3.8 #51
- build(deps-dev): bump sinon from 9.2.1 to 9.2.2 #53
- build(deps-dev): bump eslint from 7.14.0 to 7.16.0 #52
- build(deps-dev): bump @glimmer/component from 1.0.2 to 1.0.3 #55
- build(deps-dev): bump @glimmer/tracking from 1.0.0 to 1.0.3 #54
- build(deps-dev): bump ember-source from 3.23.1 to 3.24.0 #56
- build(deps-dev): bump ember-auto-import from 1.6.0 to 1.10.1 #57
- build(deps-dev): bump eslint from 7.16.0 to 7.17.0 #59
- build(deps-dev): bump eslint from 7.17.0 to 7.18.0 #60
- build(deps-dev): bump ember-source from 3.24.0 to 3.24.1 #61
- build(deps): bump socket.io from 2.3.0 to 2.4.1 #62
- build(deps-dev): bump eslint-plugin-ember from 10.0.2 to 10.1.2 #63
- build(deps-dev): bump sinon from 9.2.2 to 9.2.4 #64
- build(deps-dev): bump ember-template-lint from 2.15.0 to 2.18.0 #65
- build(deps-dev): bump eslint from 7.18.0 to 7.19.0 #66
- build(deps-dev): bump eslint-plugin-ember from 10.1.2 to 10.2.0 #67
- build(deps-dev): bump eslint from 7.19.0 to 7.20.0 #69
- build(deps): bump ember-cli-babel from 7.23.0 to 7.23.1 #70
- build(deps): bump ember-cli-htmlbars from 5.3.1 to 5.3.2 #74
- build(deps-dev): bump ember-template-lint from 2.18.0 to 2.19.0 #73