### PR TITLE
Update Pendo snippet to include track method

### DIFF
--- a/addon/metrics-adapters/pendo.js
+++ b/addon/metrics-adapters/pendo.js
@@ -21,7 +21,7 @@ export default class PendoAdapter extends BaseAdapter {
 
     /* eslint-disable */
     !(function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-    v=['initialize','identify','updateOptions','pageLoad'];for(w=0,x=v.length;w<x;++w)(function(m){
+    v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
     o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
     y=e.createElement(n);y.async=!0;y.src=`https://cdn.pendo.io/agent/static/${apiKey}/pendo.js`;
     z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');

--- a/tests/unit/metrics-adapters/pendo-test.js
+++ b/tests/unit/metrics-adapters/pendo-test.js
@@ -45,7 +45,6 @@ module("Unit | Metrics Adapter | pendo adapter", function(hooks) {
 
   test("#trackEvent calls `pendo.track` with the right arguments", function(assert) {
     let adapter = Pendo.create({ config })
-    window.pendo.track = () => {} // doesn't have a track method unless it's a real api key etc
     let stub = sinon.stub(window.pendo, "track").callsFake(() => {
       return true
     })


### PR DESCRIPTION
# Feature

Updates the Pendo snippet to include the `track` functionality in order to match the current Pendo snippet ([link to Pendo snippet documentation](https://support.pendo.io/hc/en-us/articles/360046272771)). The newer version includes `track` as one of the functions defined in the snippet.

This inclusion also means that mocking `window.pendo.track` is no longer required in the `#trackEvent` test.

## Background

My organization is using this plugin for our Pendo integration, however we recently ran into an issue when a user is using an adblocker. 

Because of the way the snippet works, if access to `https://cdn.pendo.io/agent/static/${apiKey}/pendo.js` is blocked or fails in some other way, function definitions for 'initialize', 'identify', 'updateOptions', 'pageLoad' are still created so the application fails to log, but gracefully and without impacting the site's functionality. 

However, if track events are implemented using the `trackEvent` method (`window.pendo.track`) its absence causes failures, namely a `TypeError: window.pendo.track is not a function`.

The addition of the track method in the snippet resolves this situation.