### PR TITLE
build: temp disable of canary tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@
 #$   - scenario: ember-lts-3.20
 #$   - scenario: ember-release
 #$   - scenario: ember-beta
-#$   - scenario: ember-canary
 #$   - scenario: ember-default-with-jquery
 #$   - scenario: ember-classic
 #$ nodeVersion: '10'
@@ -178,7 +177,6 @@ jobs:
           ember-lts-3.20,
           ember-release,
           ember-beta,
-          ember-canary,
           ember-default-with-jquery,
           ember-classic
         ]

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -46,14 +46,14 @@ module.exports = async function () {
           },
         },
       },
-      {
-        name: 'ember-canary',
-        npm: {
-          devDependencies: {
-            'ember-source': await getChannelURL('canary'),
-          },
-        },
-      },
+      // {
+      //   name: 'ember-canary',
+      //   npm: {
+      //     devDependencies: {
+      //       'ember-source': await getChannelURL('canary'),
+      //     },
+      //   },
+      // },
       {
         name: 'ember-default-with-jquery',
         env: {


### PR DESCRIPTION
Disables canary tests temporarily so we can publish releases again.