### PR TITLE
drop nodejs v10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@
 #$   - scenario: ember-release
 #$   - scenario: ember-default-with-jquery
 #$   - scenario: ember-classic
-#$ nodeVersion: '10'
+#$ nodeVersion: '12'
 #$ packageManager: yarn
 #
 
@@ -34,7 +34,7 @@ on:
   pull_request:
 
 env:
-  NODE_VERSION: '10'
+  NODE_VERSION: '12'
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ember-metrics-pendo allows to configure the [Pendo](https://www.pendo.io) servic
 
 * Ember.js v3.12 or above
 * Ember CLI v2.13 or above
-* Node.js v10 or above
+* Node.js v12 or above
 
 
 ## Installation


### PR DESCRIPTION
## CI

### Use Node.js version 12 (#140)


## Documentation

### Update Node.js requirement to v12 (#140)
