### PR TITLE
refactor: remove useless ember-classic-decorator 

### DIFF
--- a/addon/metrics-adapters/pendo.js
+++ b/addon/metrics-adapters/pendo.js
@@ -1,16 +1,15 @@
 import { assign } from '@ember/polyfills'
 import { assert } from '@ember/debug'
 import removeFromDOM from 'ember-metrics/utils/remove-from-dom'
-import classic from 'ember-classic-decorator'
 import BaseAdapter from 'ember-metrics/metrics-adapters/base'
 
-@classic
 export default class PendoAdapter extends BaseAdapter {
   toStringExtension() {
     return 'Pendo'
   }
 
-  init() {
+  constructor(...args) {
+    super(...args)
     let config = assign({}, this.config)
     let { apiKey } = config
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-classic-decorator": "^2.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-metrics": "^1.3.1"


### PR DESCRIPTION
## refactor

### Remove useless ember-classic-decorator