### PR TITLE
feat: add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 [![CI](https://github.com/peopledoc/ember-metrics-pendo/actions/workflows/ci.yml/badge.svg)](https://github.com/peopledoc/ember-metrics-pendo/actions/workflows/ci.yml) [![Ember Observer Score](https://emberobserver.com/badges/ember-metrics-pendo.svg)](https://emberobserver.com/addons/ember-metrics-pendo)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+## Deprecation Warning ⚠️
+
+> This add-on has been merged into [`ember-metrics`](https://github.com/adopted-ember-addons/ember-metrics).
+>
+> Please use `ember-metrics` v1.4.0+ instead and remove `ember-metrics-pendo` from your dependencies.
+
 ## About this addon
 
 Ember-metrics-pendo allows to configure the [Pendo](https://www.pendo.io) service in your ember project using [ember-metrics](https://github.com/poteto/ember-metrics).

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -25,6 +25,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-release',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('release'),
@@ -33,6 +34,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-beta',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('beta'),
@@ -41,6 +43,7 @@ module.exports = async function () {
       },
       {
         name: 'ember-canary',
+        allowedToFail: true,
         npm: {
           devDependencies: {
             'ember-source': await getChannelURL('canary'),
@@ -78,8 +81,12 @@ module.exports = async function () {
           },
         },
       },
-      embroiderSafe(),
-      embroiderOptimized(),
+      embroiderSafe({
+        allowedToFail: true,
+      }),
+      embroiderOptimized({
+        allowedToFail: true,
+      }),
     ],
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,4 +2,13 @@
 
 module.exports = {
   name: require('./package').name,
+
+  included(parent) {
+    this._super.included.apply(this, arguments)
+    console.warn(
+      `⚠️  DEPRECATION: [ember-metrics-pendo] Please use ember-metrics v1.4.0+ which includes the adapter for Pendo and remove ember-metrics-pendo from your dependencies.
+See https://github.com/adopted-ember-addons/ember-metrics for more details.`
+    )
+    return parent
+  },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-metrics-pendo",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "An ember-metrics integration for Pendo.",
   "keywords": [
     "ember-addon"
@@ -29,7 +29,7 @@
     "ember-classic-decorator": "^2.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^6.0.0",
-    "ember-metrics": "^1.3.1"
+    "ember-metrics": "~1.3.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4973,7 +4973,7 @@ ember-maybe-import-regenerator@^1.0.0:
     ember-cli-babel "^7.26.6"
     regenerator-runtime "^0.13.2"
 
-ember-metrics@^1.3.1:
+ember-metrics@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-metrics/-/ember-metrics-1.3.1.tgz#2b90dd6e8356ee124ce35dbd4bac29cc22b49898"
   integrity sha512-0feFXLXvgodjjBb02SvQT2isCifcXmJTIizqwRDgl6kgEUWPYreUBLvNUHm8pgddRGI1e/o5115dx5lYeoH9Vg==


### PR DESCRIPTION
## Feat

### Add deprecation warning (#174)

Please use ember-metrics v1.4.0+ which includes the adapter for Pendo and remove ember-metrics-pendo from your dependencies.

The version 1.3.2 is the latest version of this addon.
